### PR TITLE
Fix units reference error and ListItem.Header type error

### DIFF
--- a/src/app/qml/components/FileListItem.qml
+++ b/src/app/qml/components/FileListItem.qml
@@ -47,12 +47,12 @@ ListItem.Standard {
     }
 
     secondaryItem: RowLayout {
-        height: parent.height - units.dp(1)
-        spacing: units.dp(16)
+        height: parent.height - Units.dp(1)
+        spacing: Units.dp(16)
 
         Label {
             Layout.alignment: Qt.AlignVCenter
-            Layout.preferredWidth: units.dp(100)
+            Layout.preferredWidth: Units.dp(100)
 
             elide: Text.ElideRight
 
@@ -63,7 +63,7 @@ ListItem.Standard {
 
         Label {
             Layout.alignment: Qt.AlignVCenter
-            Layout.preferredWidth: units.dp(100)
+            Layout.preferredWidth: Units.dp(100)
 
             elide: Text.ElideRight
 

--- a/src/app/qml/components/FolderListView.qml
+++ b/src/app/qml/components/FolderListView.qml
@@ -42,17 +42,17 @@ Item {
             top: parent.top
         }
 
-        height: units.dp(48)
+        height: Units.dp(48)
 
         RowLayout {
             anchors {
                 left: parent.left
                 right: parent.right
-                margins: units.dp(16)
+                margins: Units.dp(16)
             }
 
-            height: parent.height - units.dp(1)
-            spacing: units.dp(16)
+            height: parent.height - Units.dp(1)
+            spacing: Units.dp(16)
 
             Label {
                 Layout.alignment: Qt.AlignVCenter
@@ -64,7 +64,7 @@ Item {
 
             Label {
                 Layout.alignment: Qt.AlignVCenter
-                Layout.preferredWidth: units.dp(100)
+                Layout.preferredWidth: Units.dp(100)
 
                 text: "Type"
                 color: Theme.light.subTextColor
@@ -72,7 +72,7 @@ Item {
 
             Label {
                 Layout.alignment: Qt.AlignVCenter
-                Layout.preferredWidth: units.dp(100)
+                Layout.preferredWidth: Units.dp(100)
 
                 text: "Last modified"
                 color: Theme.light.subTextColor
@@ -103,7 +103,7 @@ Item {
 
         text: i18n("No files")
         color: Theme.light.hintColor
-        font.pixelSize: units.dp(25)
+        font.pixelSize: Units.dp(25)
 
         visible: listView.count == 0
     }

--- a/src/app/qml/components/InfoSidebar.qml
+++ b/src/app/qml/components/InfoSidebar.qml
@@ -26,19 +26,19 @@ PageSidebar {
     id: infoSidebar
 
     actionBar.backgroundColor: Palette.colors.blue["600"]
-    width: units.dp(320)
+    width: Units.dp(320)
 
     showing: selectedFile != undefined
 
     actionBar.extendedContent: Item {
-        height: units.dp(72)
+        height: Units.dp(72)
         width: parent.width
 
         ColumnLayout {
             anchors.verticalCenter: parent.verticalCenter
             width: parent.width
 
-            spacing: units.dp(3)
+            spacing: Units.dp(3)
 
             Label {
                 Layout.fillWidth: true
@@ -90,25 +90,25 @@ PageSidebar {
             source: visible ? selectedFile.filePath : ""
         }
 
-        ListItem.Header {
+        ListItem.Subheader {
             text: "Info"
         }
 
         Item {
             id: infoItem
 
-            height: infoGrid.height + units.dp(16)
+            height: infoGrid.height + Units.dp(16)
             width: parent.width
 
             GridLayout {
                 id: infoGrid
 
                 anchors.horizontalCenter: parent.horizontalCenter
-                width: parent.width - units.dp(32)
+                width: parent.width - Units.dp(32)
 
                 columns: 2
-                columnSpacing: units.dp(32)
-                rowSpacing: units.dp(16)
+                columnSpacing: Units.dp(32)
+                rowSpacing: Units.dp(16)
 
                 Label {
                     text: i18n("Location")

--- a/src/app/qml/components/PlacesSidebar.qml
+++ b/src/app/qml/components/PlacesSidebar.qml
@@ -29,7 +29,7 @@ Sidebar {
             right: parent.right
         }
 
-        ListItem.Header {
+        ListItem.Subheader {
             text: "Places"
         }
 


### PR DESCRIPTION
This effectively fixes the following issues that I have reported:
- **ListItem.Header** Type not found
  - [Issue #7](https://github.com/papyros/files-app/issues/7)
- **ReferenceError** undefined reference: units
  - [Issue -8](https://github.com/papyros/files-app/issues/8)
  - [Issue -9](https://github.com/papyros/files-app/issues/9)
  - [Issue -10](https://github.com/papyros/files-app/issues/10)
