### PR TITLE
Remove nonexistent directories from PlacesModel

### DIFF
--- a/src/app/qml/components/PlacesSidebar.qml
+++ b/src/app/qml/components/PlacesSidebar.qml
@@ -59,8 +59,6 @@ Sidebar {
                 }
                 text: folderModel.pathTitle(path)
                 selected: folderModel.path == path
-                visible: text != "" && path != ""
-                enabled: visible
 
                 onClicked: folderModel.goTo(path)
             }

--- a/src/app/qml/components/PlacesSidebar.qml
+++ b/src/app/qml/components/PlacesSidebar.qml
@@ -59,6 +59,8 @@ Sidebar {
                 }
                 text: folderModel.pathTitle(path)
                 selected: folderModel.path == path
+                visible: text != "" && path != ""
+                enabled: visible
 
                 onClicked: folderModel.goTo(path)
             }

--- a/src/plugin/placesmodel/placesmodel.cpp
+++ b/src/plugin/placesmodel/placesmodel.cpp
@@ -57,8 +57,12 @@ PlacesModel::PlacesModel(QObject *parent) :
         m_locations = m_settings->value("storedLocations").toStringList();
     }
 
-    foreach (const QString &location, m_locations) {
-        qDebug() << "Location: " << location;
+    // Make sure the directories exist
+    for (const auto& location : m_locations) {
+        if(!location.isEmpty() && QDir(location).exists())
+            qDebug() << "Location: " << location;
+        else
+            m_locations.removeOne(location);
     }
 
     initNewUserMountsWatcher();

--- a/src/plugin/placesmodel/placesmodel.cpp
+++ b/src/plugin/placesmodel/placesmodel.cpp
@@ -58,7 +58,7 @@ PlacesModel::PlacesModel(QObject *parent) :
     }
 
     // Make sure the directories exist
-    for (const auto& location : m_locations) {
+    foreach(const auto& location, m_locations) {
         if(!location.isEmpty() && QDir(location).exists())
             qDebug() << "Location: " << location;
         else


### PR DESCRIPTION
### Brief:

If a user does not have one of the folders in `folderModel.places` the `ListItem` is still created and shown. There's no impact to functionality but it definitely looks off to have empty entries in the `placesSidebar`.

This change simply hides and disables entry the if the folder does not exist.

<hr>
### Changes:

 <b>1.</b> Only allow a `folderModel.places` item to be `visible:`
   and `enabled:` in the `placesSidebar` if the path and
   basename are not blank. 

<hr>
### Data:
#### Here's what files-app looks like when a user doesn't have all of the standard folders.

![papyros-files_before_edit](https://cloud.githubusercontent.com/assets/6127137/14470301/ef257c04-00a5-11e6-9e4f-4a000ec8493c.png)

<hr>
#### This is what it looks like after the check is enforced

![screenshot from 2016-04-12 12-56-36](https://cloud.githubusercontent.com/assets/6127137/14471929/1b83f822-00ae-11e6-9dbf-0b963bfc425e.png)
