### PR TITLE
Add stateful animations to searchCard 

### DIFF
--- a/src/app/qml/FolderPage.qml
+++ b/src/app/qml/FolderPage.qml
@@ -124,6 +124,18 @@ Page {
                         anchors.top: undefined
                         anchors.bottom: parent.bottom
                     }
+
+                    PropertyChanges {
+                        target: searchField
+                        focus: true
+                    }
+
+                    PropertyChanges {
+                        target: folderModel.model
+                        nameFilters: "*"
+                        filterDirectories: true
+
+                    }
                 },
                 State {
                     name: "inactive"
@@ -132,36 +144,37 @@ Page {
                         anchors.top: parent.bottom
                         anchors.bottom: undefined
                     }
+
+                    PropertyChanges {
+                        target: searchField
+                        text: ""
+                        focus: false
+
+                    }
+
+                    PropertyChanges {
+                        target: folderModel.model
+                        nameFilters: "*"
+                        filterDirectories: false
+                    }
                 }
             ]
 
             transitions: [
                 Transition {
                     to: "active"
-
                     AnchorAnimation {
+                        targets: [searchCard]
                         duration: 150
                         easing: Easing.OutQuad
-                    }
-
-                    onRunningChanged: {
-                        if(running)
-                            searchField.forceActiveFocus()
                     }
                 },
                 Transition {
                     to: "inactive"
                     AnchorAnimation {
+                        targets: [searchCard]
                         duration: 250
                         easing: Easing.InQuad
-                    }
-
-                    onRunningChanged: {
-                        if(running) {
-                            searchField.text = ""
-                            folderModel.model.nameFilters = "*"
-                            searchField.focus = false
-                        }
                     }
                 }
             ]
@@ -180,7 +193,6 @@ Page {
                     placeholderText: qsTr("Search")
                     onAccepted: {
                         folderModel.model.nameFilters = [ "*" + text + "*" ]
-                        folderModel.model.filterDirectories = true
                     }
                     Keys.onPressed: {
                         if (event.key == Qt.Key_Escape) {

--- a/src/app/qml/FolderPage.qml
+++ b/src/app/qml/FolderPage.qml
@@ -28,7 +28,6 @@ Page {
     title: folderModel.title
     actionBar.elevation: 0
 
-
     backAction: Action {
         iconName: "navigation/arrow_back"
         name: qsTr("Back")
@@ -46,7 +45,6 @@ Page {
             shortcut: StandardKey.Find
             onTriggered: searchCard.state = (searchCard.state == "active" ? "inactive" : "active")
         },
-
         // TODO enable when we have other views - ricardomv
         //Action {
         //    iconName: "action/list"
@@ -111,14 +109,12 @@ Page {
         }
 
         Card {
-            // TODO: Add animations on show/hiding search card
             id: searchCard
             width:  Units.dp(300)
             height: Units.dp(50)
             anchors.top: parent.bottom
             anchors.margins: Units.dp(8)
             anchors.horizontalCenter: parent.horizontalCenter
-
 
             states: [
                 State {
@@ -128,9 +124,6 @@ Page {
                         anchors.top: undefined
                         anchors.bottom: parent.bottom
                     }
-
-
-
                 },
                 State {
                     name: "inactive"

--- a/src/app/qml/FolderPage.qml
+++ b/src/app/qml/FolderPage.qml
@@ -28,6 +28,7 @@ Page {
     title: folderModel.title
     actionBar.elevation: 0
 
+
     backAction: Action {
         iconName: "navigation/arrow_back"
         name: qsTr("Back")
@@ -43,8 +44,9 @@ Page {
             iconName: "action/search"
             name: qsTr("Search")
             shortcut: StandardKey.Find
-            onTriggered: searchCard.visible ^= 1
+            onTriggered: searchCard.state = (searchCard.state == "active" ? "inactive" : "active")
         },
+
         // TODO enable when we have other views - ricardomv
         //Action {
         //    iconName: "action/list"
@@ -111,12 +113,66 @@ Page {
         Card {
             // TODO: Add animations on show/hiding search card
             id: searchCard
-            width: Units.dp(300)
+            width:  Units.dp(300)
             height: Units.dp(50)
-            anchors.bottom: parent.bottom
+            anchors.top: parent.bottom
             anchors.margins: Units.dp(8)
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: false
+
+
+            states: [
+                State {
+                    name: "active"
+                    AnchorChanges {
+                        target: searchCard
+                        anchors.top: undefined
+                        anchors.bottom: parent.bottom
+                    }
+
+
+
+                },
+                State {
+                    name: "inactive"
+                    AnchorChanges {
+                        target: searchCard
+                        anchors.top: parent.bottom
+                        anchors.bottom: undefined
+                    }
+                }
+            ]
+
+            transitions: [
+                Transition {
+                    to: "active"
+
+                    AnchorAnimation {
+                        duration: 150
+                        easing: Easing.OutQuad
+                    }
+
+                    onRunningChanged: {
+                        if(running)
+                            searchField.forceActiveFocus()
+                    }
+                },
+                Transition {
+                    to: "inactive"
+                    AnchorAnimation {
+                        duration: 250
+                        easing: Easing.InQuad
+                    }
+
+                    onRunningChanged: {
+                        if(running) {
+                            searchField.text = ""
+                            folderModel.model.nameFilters = "*"
+                            searchField.focus = false
+                        }
+                    }
+                }
+            ]
+
 
             RowLayout {
                 anchors.fill: parent
@@ -135,22 +191,14 @@ Page {
                     }
                     Keys.onPressed: {
                         if (event.key == Qt.Key_Escape) {
-                            searchCard.visible = false;
+                            searchCard.state = "inactive"
                         }
                     }
                 }
 
                 IconButton {
                     iconName: "navigation/close"
-                    onClicked: searchCard.visible = false
-                }
-            }
-            onVisibleChanged: {
-                if (visible) {
-                    searchField.forceActiveFocus();
-                } else {
-                    folderModel.model.nameFilters = "*";
-                    searchField.focus = false;
+                    onClicked: searchCard.state = "inactive"
                 }
             }
         }


### PR DESCRIPTION
## Brief:

This commit adds `states` and `transitions` to the `searchCard` element
in order to animate the search card when it is shown or hidden.
## Changes:

```
1. Added states and transitions to animate
   the search card

2. Added anchor animations to show the card
   sliding off and on the screen.

3. Replaced searchCard functionality which is
   based on the `visible` bool with functionality
   that uses states.
```
## Data:
#### `searchCard` States
##### active

In the `active` state `searchCard` is reanchored to the bottom of the page
##### inactive (default)

In the `inactive` state `searchCard` is anchored below the bottom of the page. 
#### `searchCard` Transitions
##### to active

When transitioning to the `active` state `searchField` is focused and animated to the positions in the `active` state which are on screen.
##### to inactive

when transitioning to the `inactive` state `searchField` and `folderModel.model.filter` are cleared and     `focus` is set to `false`. `searchCard` is then animated off screen.
##### Here's what the animation looks like

![after_edit](https://cloud.githubusercontent.com/assets/6127137/14516497/c8ee2bdc-01c0-11e6-8971-33063f933992.gif)
